### PR TITLE
Add public initializer to NSLogInterceptor

### DIFF
--- a/BothamNetworking/NSLogInterceptor.swift
+++ b/BothamNetworking/NSLogInterceptor.swift
@@ -10,6 +10,8 @@ import Foundation
 
 public class NSLogInterceptor: BothamRequestInterceptor, BothamResponseInterceptor {
 
+    public init() {}
+    
     public func intercept(request: HTTPRequest) -> HTTPRequest {
         NSLog("-> \(request)")
         return request


### PR DESCRIPTION
To be able to use NSLogInterceptor out of the library we need to add a new public init method. Without this method this class can't be used outside the library.