### PR TITLE
Add retry mechanism to the response interceptors.

### DIFF
--- a/BothamNetworking.xcodeproj/project.pbxproj
+++ b/BothamNetworking.xcodeproj/project.pbxproj
@@ -24,6 +24,8 @@
 		EB5BD5241C32A10A00C02CDA /* BothamResponseInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB5BD5231C32A10A00C02CDA /* BothamResponseInterceptor.swift */; };
 		EB5BD5261C32A32A00C02CDA /* SpyResponseInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB5BD5251C32A32A00C02CDA /* SpyResponseInterceptor.swift */; };
 		EB8F442F1BFF442F00CC3AA5 /* BothamNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = EB8F442E1BFF442F00CC3AA5 /* BothamNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EB90F5EE1C47982F00DA5E3C /* BothamRetryRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB90F5ED1C47982F00DA5E3C /* BothamRetryRequestTests.swift */; };
+		EB90F5F01C4798E800DA5E3C /* RetryResponseInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB90F5EF1C4798E800DA5E3C /* RetryResponseInterceptor.swift */; };
 		EBACCC591BFF463700F1CD7F /* BothamNetworking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EB8F442B1BFF442F00CC3AA5 /* BothamNetworking.framework */; };
 		EBACCC631BFF72B300F1CD7F /* HTTPClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBACCC621BFF72B300F1CD7F /* HTTPClient.swift */; };
 		EBACCC651BFF734800F1CD7F /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBACCC641BFF734800F1CD7F /* HTTPRequest.swift */; };
@@ -74,6 +76,8 @@
 		EB8F442B1BFF442F00CC3AA5 /* BothamNetworking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BothamNetworking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB8F442E1BFF442F00CC3AA5 /* BothamNetworking.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BothamNetworking.h; sourceTree = "<group>"; };
 		EB8F44301BFF442F00CC3AA5 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		EB90F5ED1C47982F00DA5E3C /* BothamRetryRequestTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BothamRetryRequestTests.swift; sourceTree = "<group>"; };
+		EB90F5EF1C4798E800DA5E3C /* RetryResponseInterceptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RetryResponseInterceptor.swift; sourceTree = "<group>"; };
 		EBACCC541BFF463700F1CD7F /* BothamNetworkingTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BothamNetworkingTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EBACCC581BFF463700F1CD7F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EBACCC621BFF72B300F1CD7F /* HTTPClient.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPClient.swift; sourceTree = "<group>"; };
@@ -172,6 +176,7 @@
 			children = (
 				EB5BD51A1C31A60500C02CDA /* SpyRequestInterceptor.swift */,
 				EB5BD5251C32A32A00C02CDA /* SpyResponseInterceptor.swift */,
+				EB90F5EF1C4798E800DA5E3C /* RetryResponseInterceptor.swift */,
 			);
 			name = "Test Doubles";
 			sourceTree = "<group>";
@@ -228,6 +233,7 @@
 				6B7BCF011C355BE500147FBD /* BothamNetworkingTestCase.swift */,
 				EBF3593E1C03081200AD47C4 /* BothamAPIClientTests.swift */,
 				6B7BCEFF1C35538F00147FBD /* BasicAuthenticationTests.swift */,
+				EB90F5ED1C47982F00DA5E3C /* BothamRetryRequestTests.swift */,
 				EBE2C3BA1C3EB49C0096A24C /* Extensions */,
 				EBF3593B1BFF8F6300AD47C4 /* Matchers */,
 				EBF359361BFF8E6500AD47C4 /* Http */,
@@ -502,7 +508,9 @@
 				EBF3593F1C03081200AD47C4 /* BothamAPIClientTests.swift in Sources */,
 				6B7BCF001C35538F00147FBD /* BasicAuthenticationTests.swift in Sources */,
 				6B7BCF021C355BE500147FBD /* BothamNetworkingTestCase.swift in Sources */,
+				EB90F5F01C4798E800DA5E3C /* RetryResponseInterceptor.swift in Sources */,
 				EB5BD5261C32A32A00C02CDA /* SpyResponseInterceptor.swift in Sources */,
+				EB90F5EE1C47982F00DA5E3C /* BothamRetryRequestTests.swift in Sources */,
 				EBF3593A1BFF8EF700AD47C4 /* NocillaTestCase.swift in Sources */,
 				EBF359381BFF8E7B00AD47C4 /* NSHTTPClientTests.swift in Sources */,
 				EBF3593D1BFF8F7600AD47C4 /* FutureMatchers.swift in Sources */,

--- a/BothamNetworking.xcodeproj/project.pbxproj
+++ b/BothamNetworking.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		6B7BCF021C355BE500147FBD /* BothamNetworkingTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B7BCF011C355BE500147FBD /* BothamNetworkingTestCase.swift */; };
 		D631FF669467EFA331BB0AEC /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A18346BC8A4CC5BD56E0F20B /* Pods.framework */; };
 		DAF48DF591D309FABB4E7FC6 /* Pods_BothamNetworkingTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FB776DA923364C274134982C /* Pods_BothamNetworkingTests.framework */; };
+		EB196FDD1C47E31C0080EDB9 /* BothamAPIClientError.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB196FDC1C47E31C0080EDB9 /* BothamAPIClientError.swift */; };
 		EB355DC81C33FD80003411DA /* HTTPEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB355DC71C33FD80003411DA /* HTTPEncoder.swift */; };
 		EB355DCB1C33FDE4003411DA /* HTTPEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB355DCA1C33FDE4003411DA /* HTTPEncoderTests.swift */; };
 		EB3973191C3A671000AF37CD /* NSLogInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB3973181C3A671000AF37CD /* NSLogInterceptor.swift */; };
@@ -63,6 +64,7 @@
 		A18346BC8A4CC5BD56E0F20B /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D74D9F63C2D03CEA7DEAAA3F /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		E724BA9CE7EC719AD8EEF534 /* Pods-BothamNetworkingTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BothamNetworkingTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-BothamNetworkingTests/Pods-BothamNetworkingTests.release.xcconfig"; sourceTree = "<group>"; };
+		EB196FDC1C47E31C0080EDB9 /* BothamAPIClientError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BothamAPIClientError.swift; sourceTree = "<group>"; };
 		EB355DC71C33FD80003411DA /* HTTPEncoder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPEncoder.swift; sourceTree = "<group>"; };
 		EB355DCA1C33FDE4003411DA /* HTTPEncoderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HTTPEncoderTests.swift; sourceTree = "<group>"; };
 		EB3973181C3A671000AF37CD /* NSLogInterceptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSLogInterceptor.swift; sourceTree = "<group>"; };
@@ -261,6 +263,7 @@
 			isa = PBXGroup;
 			children = (
 				EBE2C3BB1C3EB4D20096A24C /* ResultTypeTests.swift */,
+				EB196FDC1C47E31C0080EDB9 /* BothamAPIClientError.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -510,6 +513,7 @@
 				6B7BCF021C355BE500147FBD /* BothamNetworkingTestCase.swift in Sources */,
 				EB90F5F01C4798E800DA5E3C /* RetryResponseInterceptor.swift in Sources */,
 				EB5BD5261C32A32A00C02CDA /* SpyResponseInterceptor.swift in Sources */,
+				EB196FDD1C47E31C0080EDB9 /* BothamAPIClientError.swift in Sources */,
 				EB90F5EE1C47982F00DA5E3C /* BothamRetryRequestTests.swift in Sources */,
 				EBF3593A1BFF8EF700AD47C4 /* NocillaTestCase.swift in Sources */,
 				EBF359381BFF8E7B00AD47C4 /* NSHTTPClientTests.swift in Sources */,

--- a/BothamNetworking/BasicAuthentication.swift
+++ b/BothamNetworking/BasicAuthentication.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Result
 
 /**
  * Basic Authentication http://tools.ietf.org/html/rfc2617
@@ -29,7 +30,8 @@ extension BasicAuthentication {
         return request.appendingHeaders(header)
     }
 
-    public func intercept(response: HTTPResponse) -> HTTPResponse {
+    public func intercept(response: HTTPResponse,
+        completion: (Result<HTTPResponse, BothamAPIClientError>) -> Void) {
         if response.statusCode == 401, let unauthorizedHeader = response.headers?["WWW-Authenticate"] {
             let regex = try! NSRegularExpression(pattern: "Basic realm=\"(.*)\"", options: [])
             let range = NSMakeRange(0, unauthorizedHeader.utf8.count)
@@ -38,6 +40,6 @@ extension BasicAuthentication {
                 onAuthenticationError(realm)
             }
         }
-        return response
+        completion(Result.Success(response))
     }
 }

--- a/BothamNetworking/BothamAPIClient.swift
+++ b/BothamNetworking/BothamAPIClient.swift
@@ -97,7 +97,7 @@ public class BothamAPIClient {
                 completion(result)
             } else if let response = result.value {
                 self.applyResponseInterceptors(response) { interceptorResult in
-                    let mappedResult = result.flatMap { httpResponse in
+                    let mappedResult = interceptorResult.flatMap { httpResponse in
                         return self.mapHTTPResponseToBothamAPIClientError(httpResponse)
                     }
                     completion(mappedResult)

--- a/BothamNetworking/BothamAPIClient.swift
+++ b/BothamNetworking/BothamAPIClient.swift
@@ -82,7 +82,7 @@ public class BothamAPIClient {
                 completion(Result.Failure(BothamAPIClientError.UnsupportedURLScheme))
             } else {
                 sendRequest(interceptedRequest) { result in
-                    if let error = result.error where error == .Retry {
+                    if let error = result.error, case .Retry = error {
                         self.sendRequest(httpMethod,
                             path: path,
                             params: params,

--- a/BothamNetworking/BothamAPIClient.swift
+++ b/BothamNetworking/BothamAPIClient.swift
@@ -82,7 +82,7 @@ public class BothamAPIClient {
                 completion(Result.Failure(BothamAPIClientError.UnsupportedURLScheme))
             } else {
                 sendRequest(interceptedRequest) { result in
-                    if let error = result.error where error == .RetryError {
+                    if let error = result.error where error == .Retry {
                         self.sendRequest(httpMethod,
                             path: path,
                             params: params,
@@ -133,10 +133,6 @@ public class BothamAPIClient {
         completion: (Result<HTTPResponse, BothamAPIClientError>) -> Void) {
             if interceptors.isEmpty {
                 completion(Result.Success(response))
-            } else if interceptors.count == 1 {
-                interceptors[0].intercept(response) { result in
-                    completion(result)
-                }
             } else {
                 interceptors[0].intercept(response) { result in
                     if let response = result.value {

--- a/BothamNetworking/BothamAPIClient.swift
+++ b/BothamNetworking/BothamAPIClient.swift
@@ -83,7 +83,12 @@ public class BothamAPIClient {
             } else {
                 sendRequest(interceptedRequest) { result in
                     if let error = result.error where error == .RetryError {
-                        self.sendRequest(httpMethod, path: path, params: params, headers: headers, body: body, completion: completion)
+                        self.sendRequest(httpMethod,
+                            path: path,
+                            params: params,
+                            headers: headers,
+                            body: body,
+                            completion: completion)
                     } else {
                         completion(result)
                     }

--- a/BothamNetworking/BothamAPIClientError.swift
+++ b/BothamNetworking/BothamAPIClientError.swift
@@ -15,7 +15,7 @@ public enum BothamAPIClientError: ErrorType, Equatable {
     case HTTPClientError(error: NSError)
     case ParsingError(error: NSError)
     case UnsupportedURLScheme
-    case RetryError
+    case Retry
 
 }
 
@@ -31,7 +31,7 @@ public func == (lhs: BothamAPIClientError, rhs: BothamAPIClientError) -> Bool {
         return true
     case (.ParsingError(_), .ParsingError(_)):
         return true
-    case (.RetryError, .RetryError):
+    case (.Retry, .Retry):
         return true
     default:
         return false

--- a/BothamNetworking/BothamAPIClientError.swift
+++ b/BothamNetworking/BothamAPIClientError.swift
@@ -15,5 +15,6 @@ public enum BothamAPIClientError: ErrorType {
     case HTTPClientError(error: NSError)
     case ParsingError(error: NSError)
     case UnsupportedURLScheme
+    case RetryableError
 
 }

--- a/BothamNetworking/BothamAPIClientError.swift
+++ b/BothamNetworking/BothamAPIClientError.swift
@@ -8,13 +8,32 @@
 
 import Foundation
 
-public enum BothamAPIClientError: ErrorType {
+public enum BothamAPIClientError: ErrorType, Equatable {
 
     case HTTPResponseError(statusCode: Int, body: NSData)
     case NetworkError
     case HTTPClientError(error: NSError)
     case ParsingError(error: NSError)
     case UnsupportedURLScheme
-    case RetryableError
+    case RetryError
 
+}
+
+public func == (lhs: BothamAPIClientError, rhs: BothamAPIClientError) -> Bool {
+    switch (lhs, rhs) {
+    case let (.HTTPResponseError(statusCode1, body1), .HTTPResponseError(statusCode2, body2)):
+        return statusCode1 == statusCode2 && body1 == body2
+    case let (.HTTPClientError(error1), .HTTPClientError(error2)):
+        return error1 == error2
+    case (.NetworkError, .NetworkError):
+        return true
+    case (.UnsupportedURLScheme, .UnsupportedURLScheme):
+        return true
+    case (.ParsingError(_), .ParsingError(_)):
+        return true
+    case (.RetryError, .RetryError):
+        return true
+    default:
+        return false
+    }
 }

--- a/BothamNetworking/BothamAPIClientError.swift
+++ b/BothamNetworking/BothamAPIClientError.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum BothamAPIClientError: ErrorType, Equatable {
+public enum BothamAPIClientError: ErrorType {
 
     case HTTPResponseError(statusCode: Int, body: NSData)
     case NetworkError
@@ -17,23 +17,4 @@ public enum BothamAPIClientError: ErrorType, Equatable {
     case UnsupportedURLScheme
     case Retry
 
-}
-
-public func == (lhs: BothamAPIClientError, rhs: BothamAPIClientError) -> Bool {
-    switch (lhs, rhs) {
-    case let (.HTTPResponseError(statusCode1, body1), .HTTPResponseError(statusCode2, body2)):
-        return statusCode1 == statusCode2 && body1 == body2
-    case let (.HTTPClientError(error1), .HTTPClientError(error2)):
-        return error1 == error2
-    case (.NetworkError, .NetworkError):
-        return true
-    case (.UnsupportedURLScheme, .UnsupportedURLScheme):
-        return true
-    case (.ParsingError(_), .ParsingError(_)):
-        return true
-    case (.Retry, .Retry):
-        return true
-    default:
-        return false
-    }
 }

--- a/BothamNetworking/BothamResponseInterceptor.swift
+++ b/BothamNetworking/BothamResponseInterceptor.swift
@@ -7,9 +7,10 @@
 //
 
 import Foundation
+import Result
 
 public protocol BothamResponseInterceptor {
 
-    func intercept(response: HTTPResponse) -> HTTPResponse
+    func intercept(response: HTTPResponse, completion: (Result<HTTPResponse, BothamAPIClientError>) -> Void)
 
 }

--- a/BothamNetworking/NSLogInterceptor.swift
+++ b/BothamNetworking/NSLogInterceptor.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Result
 
 public class NSLogInterceptor: BothamRequestInterceptor, BothamResponseInterceptor {
 
@@ -17,8 +18,9 @@ public class NSLogInterceptor: BothamRequestInterceptor, BothamResponseIntercept
         return request
     }
 
-    public func intercept(response: HTTPResponse) -> HTTPResponse {
+    public func intercept(response: HTTPResponse,
+        completion: (Result<HTTPResponse, BothamAPIClientError>) -> Void) {
         NSLog("<- \(response)")
-        return response
+        completion(Result.Success(response))
     }
 }

--- a/BothamNetworkingTests/BothamAPIClientError.swift
+++ b/BothamNetworkingTests/BothamAPIClientError.swift
@@ -1,0 +1,31 @@
+//
+//  BothamAPIClientError.swift
+//  BothamNetworking
+//
+//  Created by Pedro Vicente Gomez on 14/01/16.
+//  Copyright © 2016 GoKarumi S.L. All rights reserved.
+//
+
+import Foundation
+import BothamNetworking
+
+extension BothamAPIClientError: Equatable { }
+
+public func == (lhs: BothamAPIClientError, rhs: BothamAPIClientError) -> Bool {
+    switch (lhs, rhs) {
+    case let (.HTTPResponseError(statusCode1, body1), .HTTPResponseError(statusCode2, body2)):
+        return statusCode1 == statusCode2 && body1 == body2
+    case let (.HTTPClientError(error1), .HTTPClientError(error2)):
+        return error1 == error2
+    case (.NetworkError, .NetworkError):
+        return true
+    case (.UnsupportedURLScheme, .UnsupportedURLScheme):
+        return true
+    case (.ParsingError(_), .ParsingError(_)):
+        return true
+    case (.Retry, .Retry):
+        return true
+    default:
+        return false
+    }
+}

--- a/BothamNetworkingTests/BothamNetworkingTestCase.swift
+++ b/BothamNetworkingTests/BothamNetworkingTestCase.swift
@@ -32,4 +32,27 @@ class BothamNetworkingTestCase: NocillaTestCase {
             }
             return bothamAPIClient
     }
+
+    func givenABothamAPIClientWithLocal(
+        requestInterceptor requestInterceptors: [BothamRequestInterceptor] = [BothamRequestInterceptor](),
+        responseInterceptors: [BothamResponseInterceptor] = [BothamResponseInterceptor]()) -> BothamAPIClient {
+            let bothamAPIClient = givenABothamAPIClient()
+            bothamAPIClient.requestInterceptors.appendContentsOf(requestInterceptors)
+            bothamAPIClient.responseInterceptors.appendContentsOf(responseInterceptors)
+            return bothamAPIClient
+    }
+
+    func givenABothamAPIClientWithGlobal(
+        requestInterceptor requestInterceptor: BothamRequestInterceptor? = nil,
+        responseInterceptor: BothamResponseInterceptor? = nil)
+        -> BothamAPIClient {
+            let bothamAPIClient = givenABothamAPIClient()
+            if let interceptor = requestInterceptor {
+                BothamAPIClient.globalRequestInterceptors.append(interceptor)
+            }
+            if let interceptor = responseInterceptor {
+                BothamAPIClient.globalResponseInterceptors.append(interceptor)
+            }
+            return bothamAPIClient
+    }
 }

--- a/BothamNetworkingTests/BothamRetryRequestTests.swift
+++ b/BothamNetworkingTests/BothamRetryRequestTests.swift
@@ -1,0 +1,31 @@
+//
+//  BothamRetryRequestTests.swift
+//  BothamNetworking
+//
+//  Created by Pedro Vicente Gomez on 14/01/16.
+//  Copyright © 2016 GoKarumi S.L. All rights reserved.
+//
+
+import Foundation
+import Nimble
+import Result
+import Nocilla
+import BothamNetworking
+
+class BothamRetryRequestTests: BothamNetworkingTestCase {
+
+    func testShouldRetryRequestIfResponseInterceptorsReturnsARetryError() {
+        stubRequest(anyHTTPMethod.rawValue, anyHost + anyPath)
+        let interceptor = RetryResponseInterceptor(numberOfRetries: 1)
+        let apiClient = givenABothamAPIClientWithLocal(responseInterceptor: interceptor)
+
+        var response: Result<HTTPResponse, BothamAPIClientError>!
+        apiClient.GET(anyPath) { result in
+            response = result
+        }
+
+        expect(response).toEventually(beSuccess())
+        expect(interceptor.interceptCalls).to(equal(2))
+    }
+
+}

--- a/BothamNetworkingTests/BothamRetryRequestTests.swift
+++ b/BothamNetworkingTests/BothamRetryRequestTests.swift
@@ -14,7 +14,7 @@ import BothamNetworking
 
 class BothamRetryRequestTests: BothamNetworkingTestCase {
 
-    func testShouldRetryRequestIfResponseInterceptorsReturnsARetryError() {
+    func testRetriesRequestIfResponseInterceptorsReturnsARetryError() {
         stubRequest(anyHTTPMethod.rawValue, anyHost + anyPath)
         let interceptor = RetryResponseInterceptor(numberOfRetries: 1)
         let apiClient = givenABothamAPIClientWithLocal(responseInterceptor: interceptor)
@@ -26,6 +26,20 @@ class BothamRetryRequestTests: BothamNetworkingTestCase {
 
         expect(response).toEventually(beSuccess())
         expect(interceptor.interceptCalls).to(equal(2))
+    }
+
+    func testRetriesRequestsMoreThanOnce() {
+        stubRequest(anyHTTPMethod.rawValue, anyHost + anyPath)
+        let interceptor = RetryResponseInterceptor(numberOfRetries: 2)
+        let apiClient = givenABothamAPIClientWithLocal(responseInterceptor: interceptor)
+
+        var response: Result<HTTPResponse, BothamAPIClientError>!
+        apiClient.GET(anyPath) { result in
+            response = result
+        }
+
+        expect(response).toEventually(beSuccess())
+        expect(interceptor.interceptCalls).to(equal(3))
     }
 
 }

--- a/BothamNetworkingTests/FutureMatchers.swift
+++ b/BothamNetworkingTests/FutureMatchers.swift
@@ -30,22 +30,3 @@ func failWithError<T>(expectedError: BothamAPIClientError) -> MatcherFunc<T?> {
         }
     }
 }
-
-extension BothamAPIClientError: Equatable { }
-
-public func == (lhs: BothamAPIClientError, rhs: BothamAPIClientError) -> Bool {
-    switch (lhs, rhs) {
-    case let (.HTTPResponseError(statusCode1, body1), .HTTPResponseError(statusCode2, body2)):
-        return statusCode1 == statusCode2 && body1 == body2
-    case let (.HTTPClientError(error1), .HTTPClientError(error2)):
-        return error1 == error2
-    case (.NetworkError, .NetworkError):
-        return true
-    case (.UnsupportedURLScheme, .UnsupportedURLScheme):
-        return true
-    case (.ParsingError(_), .ParsingError(_)):
-        return true
-    default:
-        return false
-    }
-}

--- a/BothamNetworkingTests/RetryResponseInterceptor.swift
+++ b/BothamNetworkingTests/RetryResponseInterceptor.swift
@@ -1,0 +1,31 @@
+//
+//  RetryResponseInterceptor.swift
+//  BothamNetworking
+//
+//  Created by Pedro Vicente Gomez on 14/01/16.
+//  Copyright © 2016 GoKarumi S.L. All rights reserved.
+//
+
+import Foundation
+import BothamNetworking
+import Result
+
+class RetryResponseInterceptor: BothamResponseInterceptor {
+
+    var interceptCalls = 0
+    var numberOfRetries: Int
+
+    init(numberOfRetries: Int) {
+        self.numberOfRetries = numberOfRetries
+    }
+
+    func intercept(response: HTTPResponse, completion: (Result<HTTPResponse, BothamAPIClientError>) -> Void) {
+        interceptCalls++
+        if numberOfRetries > 0 {
+            numberOfRetries--
+            completion(Result.Failure(.RetryError))
+        } else {
+            completion(Result.Success(response))
+        }
+    }
+}

--- a/BothamNetworkingTests/RetryResponseInterceptor.swift
+++ b/BothamNetworkingTests/RetryResponseInterceptor.swift
@@ -23,7 +23,7 @@ class RetryResponseInterceptor: BothamResponseInterceptor {
         interceptCalls++
         if numberOfRetries > 0 {
             numberOfRetries--
-            completion(Result.Failure(.RetryError))
+            completion(Result.Failure(.Retry))
         } else {
             completion(Result.Success(response))
         }

--- a/BothamNetworkingTests/SpyResponseInterceptor.swift
+++ b/BothamNetworkingTests/SpyResponseInterceptor.swift
@@ -14,11 +14,16 @@ class SpyResponseInterceptor: BothamResponseInterceptor {
 
     var intercepted: Bool = false
     var interceptedResponse: HTTPResponse!
+    var error: BothamAPIClientError? = nil
 
     func intercept(response: HTTPResponse, completion: (Result<HTTPResponse, BothamAPIClientError>) -> Void) {
         intercepted = true
         interceptedResponse = response
-        completion(Result.Success(response))
+        if let error = error {
+            completion(Result.Failure(error))
+        } else {
+            completion(Result.Success(response))
+        }
     }
 }
 

--- a/BothamNetworkingTests/SpyResponseInterceptor.swift
+++ b/BothamNetworkingTests/SpyResponseInterceptor.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Result
 @testable import BothamNetworking
 
 class SpyResponseInterceptor: BothamResponseInterceptor {
@@ -14,10 +15,10 @@ class SpyResponseInterceptor: BothamResponseInterceptor {
     var intercepted: Bool = false
     var interceptedResponse: HTTPResponse!
 
-    func intercept(response: HTTPResponse) -> HTTPResponse {
+    func intercept(response: HTTPResponse, completion: (Result<HTTPResponse, BothamAPIClientError>) -> Void) {
         intercepted = true
         interceptedResponse = response
-        return response
+        completion(Result.Success(response))
     }
 }
 


### PR DESCRIPTION
I've moved the ``BothamAPIClientError`` equatable implementation from the tests target to the library target because I need it in ``BothamAPIClient`` class to be able to check if the response returned by the response interceptor is a retry error. Fix #28 